### PR TITLE
Alerting and Slack Notification System for VLLM alerts [WIP]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,6 @@ cython_debug/
 # PyPI configuration file
 .pypirc
 *.pyc
+
+# macOS
+.DS_Store

--- a/deploy/helm/alerts/.helmignore
+++ b/deploy/helm/alerts/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/helm/alerts/Chart.yaml
+++ b/deploy/helm/alerts/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: alerts
+description: A Helm chart for setting up alerts and CronJob receiver
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.1.0"

--- a/deploy/helm/alerts/crds/prometheusrule.yaml
+++ b/deploy/helm/alerts/crds/prometheusrule.yaml
@@ -1,0 +1,132 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: vllm-metric-alerts
+  namespace: vllm-alerts
+  labels:
+    openshift.io/user-monitoring: "true" 
+    openshift.io/prometheus-rule-evaluation-scope: "leaf-prometheus"
+    role: alert-rules
+spec:
+  groups:
+  - name: dummy-alerts
+    interval: 0s
+    rules:
+    - alert: VLLMDummyServiceInfo
+      expr: |
+        # This will fire for every instance of vllm:request_success_total that exists
+        rate(vllm:request_success_total[1m]) >= 0
+      for: 0s 
+      labels:
+        severity: info
+        test_alert: "true"
+      annotations:
+        summary: "DUMMY ALERT: Information about vLLM service {{ $labels.service }} in namespace {{ $labels.namespace }}"
+        description: |
+          This test alert provides current context about a vLLM service instance.
+          It is always firing for testing purposes and does not indicate an issue.
+          Model Name: {{ $labels.model_name }}.
+          Affected Pod: {{ $labels.pod }}.
+          Current Rate of Successful Requests (1m): {{ $value | printf "%.2f" }} req/s
+
+    - alert: VLLMDummyAlwaysFiring
+      expr: |
+        vector(1)
+      for: 0s 
+      labels:
+        severity: info
+      annotations:
+        summary: "DUMMY ALERT: This alert is always firing for testing purposes."
+        description: |
+          This is a test alert. It is configured to always be in a firing state.
+          It does not indicate any actual issue with vLLM services.
+          Please silence or remove this alert after testing is complete.
+          Current value: {{ $value }}
+
+  - name: vllm-metric-alerts
+    interval: 15s
+    rules:
+
+    - alert: VLLMHighAbortedRequestRate
+      expr: |
+        rate(vllm:num_aborted_requests[5m]) / rate(vllm:num_total_requests[5m]) > 0.10 and rate(vllm:num_total_requests[5m]) > 0
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        summary: "High rate of aborted requests for vLLM service {{ $labels.service }} in namespace {{ $labels.namespace }}"
+        description: | 
+          More than 10% of total requests are being aborted over a 5 minute period.
+          Rate of Aborted Requests: {{ $value | printf "%.2f" }}%
+          Model Name: {{ $labels.model_name }}.
+          Affected Pod: {{ $labels.pod }}.
+
+    - alert: VLLMHighP95Latency
+      expr: |
+        histogram_quantile(0.95, sum by (instance, job, namespace, service, model_name, pod, le) (rate(vllm:e2e_request_latency_seconds_bucket[5m]))) > 5
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        summary: "High P95 end-to-end request latency for vLLM service {{ $labels.service }} in namespace {{ $labels.namespace }}"
+        description: |
+          The 95th percentile of end-to-end request latency is consistently above 5 seconds over a 5-minute window.
+          P95 Latency: {{ $value | printf "%.2f" }}s
+          Model Name: {{ $labels.model_name }}.
+          Affected Pod: {{ $labels.pod }}.
+
+    - alert: VLLMLowRequestSuccessRate
+      expr: |
+        (sum by (instance, job, namespace, service, model_name, pod) (rate(vllm:request_success_total[5m]))) / (sum by (instance, job, namespace, service, model_name, pod) (rate(vllm:num_total_requests[5m]))) < 0.95 and (sum by (instance, job, namespace, service, model_name, pod) (rate(vllm:num_total_requests[5m]))) > 0
+      for: 5m
+      labels:
+        severity: critical
+      annotations:
+        summary: "Low request success rate for vLLM service {{ $labels.service }} in namespace {{ $labels.namespace }}"
+        description: |
+          The success rate of requests has fallen below 95% over a 5-minute window.
+          Success Rate: {{ $value | printf "%.2f" }}%
+          Model Name: {{ $labels.model_name }}.
+          Affected Pod: {{ $labels.pod }}.
+
+    - alert: VLLMHighAverageInferenceTime
+      expr: |
+        rate(vllm:request_inference_time_seconds_sum[5m]) / rate(vllm:request_inference_time_seconds_count[5m]) > 2
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: "High average inference time for vLLM service {{ $labels.service }} in namespace {{ $labels.namespace }}"
+        description: |
+          The average inference time per request is consistently above 2 seconds over a 5-minute window.
+          Average Inference Time: {{ $value | printf "%.2f" }}s
+          Model Name: {{ $labels.model_name }}.
+          Affected Pod: {{ $labels.pod }}.
+
+    - alert: VLLMHighP95RequestQueueTime
+      expr: |
+        histogram_quantile(0.95, sum by (instance, job, namespace, service, model_name, pod, le) (rate(vllm:request_queue_time_seconds_bucket[5m]))) > 1
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: "High P95 request queue time for vLLM service {{ $labels.service }} in namespace {{ $labels.namespace }}"
+        description: |
+          The 95th percentile of time requests spend in the queue is consistently above 1 second over a 5-minute window, indicating potential backlog.
+          P95 Queue Time: {{ $value | printf "%.2f" }}s
+          Model Name: {{ $labels.model_name }}.
+          Affected Pod: {{ $labels.pod }}.
+
+    - alert: VLLMHighGPUCacheUsage
+      expr: |
+        vllm:gpu_cache_usage_perc > 0.9
+      for: 10m
+      labels:
+        severity: warning
+      annotations:
+        summary: "High GPU cache usage for vLLM service {{ $labels.service }} in namespace {{ $labels.namespace }}"
+        description: |
+          GPU cache usage exceeds 90%. This indicates potential memory pressure and could lead to performance degradation or OOM errors.
+          GPU Cache Usage: {{ $value | printf "%.1f" }}%
+          Model Name: {{ $labels.model_name }}.
+          Affected Pod: {{ $labels.pod }}.

--- a/deploy/helm/alerts/templates/_helpers.tpl
+++ b/deploy/helm/alerts/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "alerts.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "alerts.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "alerts.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "alerts.labels" -}}
+helm.sh/chart: {{ include "alerts.chart" . }}
+{{ include "alerts.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "alerts.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "alerts.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "alerts.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "alerts.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/alerts/templates/cronjob.yaml
+++ b/deploy/helm/alerts/templates/cronjob.yaml
@@ -1,0 +1,29 @@
+# alerts/templates/cronjob.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "alerts.fullname" . }}
+spec:
+  schedule: {{ .Values.schedule | quote }}
+  concurrencyPolicy: Forbid # Ensure only one job runs at a time
+  suspend: false
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: {{ .Values.serviceAccountName }}
+          restartPolicy: OnFailure
+          containers:
+            - name: alert-notifier
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              env:
+                {{- range .Values.env }}
+                - name: {{ .name | quote }}
+                  value: {{ .value | quote }}
+                {{- end }}
+                - name: SLACK_WEBHOOK_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.slackWebhook.secretName | quote }}
+                      key: {{ .Values.slackWebhook.secretKey | quote }}

--- a/deploy/helm/alerts/values.yaml
+++ b/deploy/helm/alerts/values.yaml
@@ -1,0 +1,23 @@
+image:
+  repository: quay.io/rh-ee-pezhao/appeng/vllm-alert-receiver
+  tag: 0.1.0
+  pullPolicy: Always
+
+schedule: "*/1 * * * *" # cron job scheduled every minute
+
+env:
+  - name: ALERTMANAGER_URL
+    value: "http://alertmanager-operated.openshift-user-workload-monitoring.svc.cluster.local:9093"
+  - name: TIME_WINDOW
+    value: 60 # Notify on alerts less than 60 seconds old
+
+slackWebhook:
+  secretName: alerts-secrets
+  secretKey: slack-webhook-url
+
+serviceAccountName: default
+
+prometheusRule:
+  name: vllm-metric-alerts
+  labels:
+    role: alert-rules 

--- a/metric-ui/alerts/Containerfile
+++ b/metric-ui/alerts/Containerfile
@@ -1,0 +1,9 @@
+FROM registry.access.redhat.com/ubi9/python-311:latest
+
+WORKDIR /app
+
+COPY . .
+
+RUN pip install requests
+
+CMD ["python3", "alert_receiver.py"]

--- a/metric-ui/alerts/alert_receiver.py
+++ b/metric-ui/alerts/alert_receiver.py
@@ -1,0 +1,108 @@
+import requests
+import json
+import os
+import datetime
+
+# --- CONFIG ---
+ALERTMANAGER_URL = os.getenv("ALERTMANAGER_URL", "http://localhost:9093")
+SLACK_WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL", "")
+TIME_WINDOW = int(os.getenv("TIME_WINDOW", 60))
+
+# pull active alerts from Alertmanager
+def get_active_alerts():
+    endpoint = f"{ALERTMANAGER_URL}/api/v2/alerts"
+    try:
+        response = requests.get(endpoint)
+        response.raise_for_status()  
+        return response.json()
+    except requests.exceptions.RequestException as e:
+        print(f"Error querying Alertmanager: {e}")
+        return None
+    
+def send_slack_message(payload):
+    headers = {"Content-Type": "application/json"}
+    if SLACK_WEBHOOK_URL == "":
+        print("No Slack URL found")
+        return False
+    try:
+        response = requests.post(SLACK_WEBHOOK_URL, headers=headers, data=json.dumps(payload))
+        response.raise_for_status()
+        print("Slack message sent successfully!")
+        return True
+    except requests.exceptions.RequestException as e:
+        print(f"Error sending Slack message: {e}")
+        return False
+    
+# formats slack message for a single alert
+def format_slack_message(alert_data):
+    alertname = alert_data['labels'].get('alertname', 'N/A')
+    severity = alert_data['labels'].get('severity', 'info').upper()
+    summary = alert_data['annotations'].get('summary', 'No summary provided.')
+    description = alert_data['annotations'].get('description', 'No description provided.')
+    generator_url = alert_data.get('generatorURL', 'No generator URL.')
+    starts_at_iso = alert_data.get('startsAt')
+
+    starts_at_formatted = "N/A"
+    if starts_at_iso:
+        try:
+            dt_object_utc = datetime.datetime.fromisoformat(starts_at_iso.replace('Z', '+00:00'))
+            starts_at_formatted = dt_object_utc.strftime('%Y-%m-%d %H:%M:%S UTC')
+        except ValueError:
+            pass
+
+    color_emoji = ""
+    if severity == "CRITICAL":
+        color_emoji = ":red_circle: "
+    elif severity == "WARNING":
+        color_emoji = ":large_orange_circle: "
+    elif severity == "INFO":
+        color_emoji = ":large_blue_circle: "
+
+    message_text = (
+        f"{color_emoji}*ALERT: {alertname} [{severity}]*\n\n"
+        f"*{summary}*\n\n"
+        f"{description}\n"
+        f"Started At: {starts_at_formatted}\n"
+        f"<{generator_url}|View on console>"
+    )
+
+    payload = {
+        "text": message_text,
+        "mrkdwn": True
+    }
+
+    return payload
+
+# filters Alertmanager alerts by name + time and sends a slack message for each resulting alert
+def process_vllm_alerts_and_notify(alerts, time_window=TIME_WINDOW):
+    if alerts:
+        now_utc = datetime.datetime.now(datetime.timezone.utc) 
+        time_threshold = now_utc - datetime.timedelta(seconds=time_window)
+
+        for alert in alerts:
+            alertname = alert['labels'].get('alertname', '')
+            starts_at_iso = alert.get('startsAt')
+            test_alert_label = alert['labels'].get('test_alert', 'false').lower()
+
+            # filter by VLLM alerts
+            if alertname.startswith("VLLM") and test_alert_label != 'true':
+                
+                if starts_at_iso:
+                    try:
+                        # filter by time, only notify on alerts that started within given time window
+                        alert_start_time_utc = datetime.datetime.fromisoformat(starts_at_iso.replace('Z', '+00:00'))
+                        if alert_start_time_utc >= time_threshold:
+                            print(f"\n--- Found NEW relevant VLLM Alert: {alertname} ---")
+                            slack_payload = format_slack_message(alert)
+                            send_slack_message(slack_payload)
+                        else:
+                            print(f"VLLM alert '{alertname}' is active but started too long ago ({alert_start_time_utc}). Skipping.")
+                    except ValueError:
+                        print(f"Warning: Could not parse startsAt time for alert '{alertname}': {starts_at_iso}")
+
+def main():
+    alerts = get_active_alerts()
+    process_vllm_alerts_and_notify(alerts)
+    
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Overview

Created alerting and Slack notification system for VLLM-relevant alerts. 
Jira: https://issues.redhat.com/browse/APPENG-3246

#### Changes:
- PrometheusRule CR with test alerts that monitor anomalies in vllm metrics
- Custom alert receiver that pulls alerts from Alertmanager and forwards them to a Slack channel given a webhook URL
- Helm charts to deploy PrometheusRule and cron job that runs the alert receiver every 1 minute

#### Deployment Steps:
1. [Enable cross-project alerting for namespace](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html-single/monitoring/index#managing-alerting-rules-for-user-defined-projects_managing-alerts-as-an-administrator)
2. Install the chart
```
helm install vllm-notifier deploy/helm/alerts --namespace vllm-alerts
```

#### Needs work:
- Current alerts are meant for initial testing and are easy to trigger. Create more realistic evaluation expressions.
- Fix bug with connecting to Alertmanager within the cron job on the cluster (Log output below):
```
Error querying Alertmanager: 
HTTPConnectionPool(host='alertmanager-operated.openshift-user-workload-monitoring.svc.cluster.local', port=9093): Max retries exceeded with url: /api/v2/alerts (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f2b2e782050>: Failed to establish a new connection: [Errno 111] Connection refused'))
```


### Screenshots
<img width="1030" alt="Screenshot 2025-06-23 at 10 33 32 AM" src="https://github.com/user-attachments/assets/2dced1bb-0977-4e33-af92-c211537eae1b" />
