### PR TITLE
Alerting and Slack Notification System for VLLM alerts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,6 @@ cython_debug/
 # PyPI configuration file
 .pypirc
 *.pyc
+
+# macOS
+.DS_Store

--- a/deploy/helm/alerting/.helmignore
+++ b/deploy/helm/alerting/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/helm/alerting/Chart.yaml
+++ b/deploy/helm/alerting/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: alerts
+description: A Helm chart for setting up alerts and CronJob receiver
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.1.0"

--- a/deploy/helm/alerting/templates/_helpers.tpl
+++ b/deploy/helm/alerting/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "alerts.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "alerts.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "alerts.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "alerts.labels" -}}
+helm.sh/chart: {{ include "alerts.chart" . }}
+{{ include "alerts.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "alerts.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "alerts.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "alerts.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "alerts.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/alerting/templates/configmap.yaml
+++ b/deploy/helm/alerting/templates/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trusted-ca-bundle-alerts
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+data:
+  service-ca.crt: "" 

--- a/deploy/helm/alerting/templates/cronjob.yaml
+++ b/deploy/helm/alerting/templates/cronjob.yaml
@@ -1,0 +1,54 @@
+# alerts/templates/cronjob.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "alerts.fullname" . }}
+spec:
+  schedule: {{ .Values.schedule | quote }}
+  concurrencyPolicy: Forbid # Ensure only one job runs at a time
+  suspend: false
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: {{ .Values.serviceAccountName }}
+          restartPolicy: OnFailure
+          containers:
+            - name: alert-notifier
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              env:
+                - name: TIME_WINDOW
+                  value: "{{ .Values.config.timeWindow }}"
+                - name: ALERTMANAGER_URL
+                  value: "{{ .Values.config.alertmanagerUrl }}"
+                - name: LLAMA_STACK_URL
+                  value: "http://llamastack.{{ .Release.Namespace }}.svc.cluster.local:8321"
+                - name: SLACK_WEBHOOK_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.slackWebhook.secretName | quote }}
+                      key: {{ .Values.slackWebhook.secretKey | quote }}
+                - name: AUTH_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.serviceAccountName }}
+                      key: token
+              volumeMounts:
+              - name: auth-token
+                mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+                readOnly: true
+              - name: trusted-ca
+                mountPath: /etc/pki/ca-trust/extracted/pem
+                readOnly: true
+          volumes:
+            - name: auth-token
+              secret:
+                secretName: {{ .Values.serviceAccountName }}
+                defaultMode: 0440
+            - name: trusted-ca
+              configMap:
+                name: trusted-ca-bundle-alerts
+                items:
+                  - key: service-ca.crt
+                    path: ca-bundle.crt

--- a/deploy/helm/alerting/templates/prometheusrule.yaml
+++ b/deploy/helm/alerting/templates/prometheusrule.yaml
@@ -1,0 +1,100 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: vllm-metric-alerts
+  labels:
+    openshift.io/user-monitoring: "true" 
+    openshift.io/prometheus-rule-evaluation-scope: "leaf-prometheus"
+    role: alert-rules
+spec:
+  groups:
+  - name: dummy-alerts
+    interval: 0s
+    rules:
+    - alert: VLLMDummyServiceInfo
+      expr: |
+        # This will fire for every instance of vllm:request_success_total that exists
+        rate(vllm:request_success_total[1m]) >= 0
+      for: 0s 
+      labels:
+        severity: info
+        test_alert: "true"
+        expr: |
+          # This will fire for every instance of vllm:request_success_total that exists
+          rate(vllm:request_success_total[1m]) >= 0
+        for: 0s 
+
+    - alert: VLLMDummyAlwaysFiring
+      expr: |
+        vector(1)
+      for: 0s 
+      labels:
+        severity: info
+        test_alert: "true"
+        expr: |
+          vector(1)
+        for: 0s 
+
+  - name: vllm-metric-alerts
+    interval: 15s
+    rules:
+
+    - alert: VLLMHighAbortedRequestRate
+      expr: |
+        rate(vllm:num_aborted_requests[5m]) / rate(vllm:num_total_requests[5m]) > 0.10 and rate(vllm:num_total_requests[5m]) > 0
+      for: 5m
+      labels:
+        severity: critical
+        expr: |
+          rate(vllm:num_aborted_requests[5m]) / rate(vllm:num_total_requests[5m]) > 0.10 and rate(vllm:num_total_requests[5m]) > 0
+        for: 5m
+
+    - alert: VLLMHighP95Latency
+      expr: |
+        histogram_quantile(0.95, sum by (instance, job, namespace, service, model_name, pod, le) (rate(vllm:e2e_request_latency_seconds_bucket[5m]))) > 5
+      for: 5m
+      labels:
+        severity: critical
+        expr: |
+          histogram_quantile(0.95, sum by (instance, job, namespace, service, model_name, pod, le) (rate(vllm:e2e_request_latency_seconds_bucket[5m]))) > 5
+        for: 5m
+
+    - alert: VLLMLowRequestSuccessRate
+      expr: |
+        (sum by (instance, job, namespace, service, model_name, pod) (rate(vllm:request_success_total[5m]))) / (sum by (instance, job, namespace, service, model_name, pod) (rate(vllm:num_total_requests[5m]))) < 0.95 and (sum by (instance, job, namespace, service, model_name, pod) (rate(vllm:num_total_requests[5m]))) > 0
+      for: 5m
+      labels:
+        severity: critical
+        expr: |
+          (sum by (instance, job, namespace, service, model_name, pod) (rate(vllm:request_success_total[5m]))) / (sum by (instance, job, namespace, service, model_name, pod) (rate(vllm:num_total_requests[5m]))) < 0.95 and (sum by (instance, job, namespace, service, model_name, pod) (rate(vllm:num_total_requests[5m]))) > 0
+        for: 5m
+
+    - alert: VLLMHighAverageInferenceTime
+      expr: |
+        rate(vllm:request_inference_time_seconds_sum[5m]) / rate(vllm:request_inference_time_seconds_count[5m]) > 2
+      for: 5m
+      labels:
+        severity: warning
+        expr: |
+          rate(vllm:request_inference_time_seconds_sum[5m]) / rate(vllm:request_inference_time_seconds_count[5m]) > 2
+        for: 5m
+
+    - alert: VLLMHighP95RequestQueueTime
+      expr: |
+        histogram_quantile(0.95, sum by (instance, job, namespace, service, model_name, pod, le) (rate(vllm:request_queue_time_seconds_bucket[5m]))) > 1
+      for: 5m
+      labels:
+        severity: warning
+        expr: |
+          histogram_quantile(0.95, sum by (instance, job, namespace, service, model_name, pod, le) (rate(vllm:request_queue_time_seconds_bucket[5m]))) > 1
+        for: 5m
+
+    - alert: VLLMHighGPUCacheUsage
+      expr: |
+        vllm:gpu_cache_usage_perc > 0.9
+      for: 10m
+      labels:
+        severity: warning
+        expr: |
+          vllm:gpu_cache_usage_perc > 0.9
+        for: 10m

--- a/deploy/helm/alerting/templates/rolebinding.yaml
+++ b/deploy/helm/alerting/templates/rolebinding.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: alertmanager-user-workload-api-read-binding 
+  namespace: openshift-user-workload-monitoring 
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccountName }} 
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role 
+  name: monitoring-alertmanager-api-reader 
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: view-thanos-{{ .Release.Namespace }}-alerts
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccountName }}
+    namespace: {{ .Release.Namespace }}
+---
+# This ClusterRoleBinding allows grafana-sa-token SA to access metrics from the OpenShift user
+# workload monitoring stack.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-monitoring-view-thanos-{{ .Release.Namespace }}-alerts
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccountName }}
+    namespace: {{ .Release.Namespace }}
+---
+# This ClusterRoleBinding allows grafana-sa-token SA to access metrics from the built-in OpenShift
+# cluster monitoring stack, required for accessing core OpenShift metrics and monitoring data
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openshift-cluster-monitoring-view-thanos-{{ .Release.Namespace }}-alerts
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-cluster-monitoring-view
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccountName }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: grafana-prometheus-reader-binding-{{ .Release.Namespace }}-alerts
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: grafana-prometheus-reader
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccountName }}
+    namespace: {{ .Release.Namespace }}

--- a/deploy/helm/alerting/templates/serviceaccount.yaml
+++ b/deploy/helm/alerting/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.serviceAccountName }}
+  namespace: {{ .Release.namespace }}
+  annotations:
+    kubernetes.io/service-account.name: {{ .Values.serviceAccountName }}
+type: kubernetes.io/service-account-token
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccountName }}

--- a/deploy/helm/alerting/values.yaml
+++ b/deploy/helm/alerting/values.yaml
@@ -1,0 +1,21 @@
+image:
+  repository: quay.io/rh-ee-pezhao/appeng/vllm-alert-receiver
+  tag: 0.1.4
+  pullPolicy: Always
+
+schedule: "*/1 * * * *" # cron job scheduled every minute
+
+slackWebhook:
+  secretName: alerts-secrets
+  secretKey: slack-webhook-url
+
+serviceAccountName: alert-receiver
+
+prometheusRule:
+  name: vllm-metric-alerts
+  labels:
+    role: alert-rules 
+
+config:
+  alertmanagerUrl: "https://alertmanager-user-workload.openshift-user-workload-monitoring.svc.cluster.local:9095"
+  timeWindow: 60

--- a/metric-ui/alerting/Containerfile
+++ b/metric-ui/alerting/Containerfile
@@ -1,0 +1,9 @@
+FROM registry.access.redhat.com/ubi9/python-311:latest
+
+WORKDIR /app
+
+RUN pip install requests llama-stack
+
+COPY . .
+
+CMD ["python3", "alert_receiver.py"]

--- a/metric-ui/alerting/Makefile
+++ b/metric-ui/alerting/Makefile
@@ -1,0 +1,9 @@
+VERSION ?= 0.1.4
+REGISTRY ?= quay.io/rh-ee-pezhao/appeng
+
+build_ui:
+	podman build --platform linux/amd64 -t vllm-alert-receiver:$(VERSION) .
+
+build_and_push_ui: build_ui
+	podman tag vllm-alert-receiver:$(VERSION) $(REGISTRY)/vllm-alert-receiver:$(VERSION)
+	podman push $(REGISTRY)/vllm-alert-receiver:$(VERSION)

--- a/metric-ui/alerting/alert_receiver.py
+++ b/metric-ui/alerting/alert_receiver.py
@@ -1,0 +1,172 @@
+import requests
+import json
+import os
+import datetime
+from llama_stack_client import LlamaStackClient
+
+# --- CONFIG ---
+ALERTMANAGER_URL = os.getenv("ALERTMANAGER_URL", "http://localhost:9093")
+SLACK_WEBHOOK_URL = os.getenv("SLACK_WEBHOOK_URL", "")
+LLAMA_STACK_URL = os.getenv("LLAMA_STACK_URL", "http://localhost:8321")
+TIME_WINDOW = int(os.getenv("TIME_WINDOW", 60))
+
+# Handle token input from volume or literal
+token_input = os.getenv("AUTH_TOKEN", "/var/run/secrets/kubernetes.io/serviceaccount/token")
+if os.path.exists(token_input):
+    with open(token_input, "r") as f:
+        AUTH_TOKEN = f.read().strip()
+else:
+    AUTH_TOKEN = token_input
+
+# CA bundle location (mounted via ConfigMap)
+CA_BUNDLE_PATH = "/etc/pki/ca-trust/extracted/pem/ca-bundle.crt"
+verify = CA_BUNDLE_PATH if os.path.exists(CA_BUNDLE_PATH) else True
+
+# --- LLAMASTACK SETUP ---
+client = LlamaStackClient(base_url=LLAMA_STACK_URL)
+llm = next(m for m in client.models.list() if m.model_type == "llm")
+
+# pull active alerts from Alertmanager
+def get_active_alerts() -> dict:
+    headers = {"Authorization": f"Bearer {AUTH_TOKEN}"}
+    endpoint = f"{ALERTMANAGER_URL}/api/v2/alerts"
+    verify = CA_BUNDLE_PATH if os.path.exists(CA_BUNDLE_PATH) else True
+    try:
+        response = requests.get(
+            endpoint,
+            headers=headers,
+            verify=verify,
+        )
+        response.raise_for_status()  
+        print("Alerts successfully retrieved from Alertmanager")
+        return response.json()
+    except requests.exceptions.RequestException as e:
+        print(f"Error querying Alertmanager: {e}")
+        return None
+
+def send_slack_message(payload):
+    headers = {"Content-Type": "application/json"}
+    if SLACK_WEBHOOK_URL == "":
+        print("No Slack URL found")
+        return False
+    try:
+        response = requests.post(SLACK_WEBHOOK_URL, headers=headers, data=json.dumps(payload))
+        response.raise_for_status()
+        print("Slack message sent successfully!")
+        return True
+    except requests.exceptions.RequestException as e:
+        print(f"Error sending Slack message: {e}")
+        return False
+    
+# generate a description based on the alert labels
+def generate_description(labels):
+    labels = json.dumps(labels)
+    prompt = """
+    You are an AI assistant designed to generate concise, informative, and *technically detailed* Slack message descriptions for OpenShift vLLM alerts. Your task is to analyze the provided alert data, *especially the 'expr' field*, and create a clear, actionable description of the problem.
+
+    Provide only the description text. Start the description with "This alert..." or "This alert indicates..." to briefly summarize the general nature of the alert. Then, use a Markdown bulleted list to detail the following points:
+    1.  Interpret the expression to explain what the issue is in understandable English. Do NOT mention "Prometheus Query Language" or include the raw expression string in your explanation. Instead, describe the metric and threshold being monitored.
+    2.  **Affected components:** Mention the model_name, pod, namespace, and service to clearly identify what is impacted. This should be in a clear bulleted list.
+    3.  Provide initial troubleshooting suggestions or common solutions to resolve the issue in a single sentence.
+
+    Do not add any prefixes like 'ALERT:' or 'Severity:' or a separate summary line. The output should be ready to be embedded directly into a Slack message.
+
+    Here is the alert data: 
+    """
+    response = client.inference.chat_completion(
+        model_id=llm.identifier,
+        messages=[
+            {"role": "system", "content": prompt},
+            {"role": "user", "content": labels},
+        ],
+        stream=False
+    )
+
+    return response.completion_message.content
+    
+# formats slack message for a single alert
+def format_slack_message(alert_data):
+    alertname = alert_data['labels'].get('alertname', 'N/A')
+    severity = alert_data['labels'].get('severity', 'info').upper()
+    generator_url = alert_data.get('generatorURL', 'No generator URL.')
+    starts_at_iso = alert_data.get('startsAt')
+
+    description = generate_description(alert_data['labels'])
+
+    # get firing start time in UTC
+    starts_at_iso = alert_data.get('startsAt')
+    starts_at_formatted = "N/A"
+    if starts_at_iso:
+        try:
+            dt_object_utc = datetime.datetime.fromisoformat(starts_at_iso.replace('Z', '+00:00'))
+            starts_at_formatted = dt_object_utc.strftime('%Y-%m-%d %H:%M:%S UTC')
+        except ValueError:
+            pass
+
+    color_emoji = ""
+    if severity == "CRITICAL":
+        color_emoji = ":red_circle: "
+    elif severity == "WARNING":
+        color_emoji = ":large_orange_circle: "
+    elif severity == "INFO":
+        color_emoji = ":large_blue_circle: "
+
+    message_text = (
+        f"{color_emoji}*ALERT: {alertname} [{severity}]*\n\n"
+        f"{description}\n\n"
+        f"Started At: {starts_at_formatted}\n"
+        f"<{generator_url}|View on console>"
+    )
+
+    payload = {
+        "text": message_text,
+        "mrkdwn": True
+    }
+
+    return payload
+
+# filters Alertmanager alerts by name + time and sends a slack message for each resulting alert
+def process_vllm_alerts_and_notify(alerts, time_window=TIME_WINDOW):
+    if alerts:
+        now_utc = datetime.datetime.now(datetime.timezone.utc) 
+        time_threshold = now_utc - datetime.timedelta(seconds=time_window)
+
+        found = False
+        for alert in alerts:
+            alertname = alert['labels'].get('alertname', '')
+            starts_at_iso = alert.get('startsAt')
+            test_alert_label = alert['labels'].get('test_alert', 'false').lower()
+
+            # filter by VLLM alerts
+            if alertname.startswith("VLLM") and test_alert_label != 'true':
+                
+                if starts_at_iso:
+                    try:
+                        # filter by time, only notify on alerts that started within given time window
+                        alert_start_time_utc = datetime.datetime.fromisoformat(starts_at_iso.replace('Z', '+00:00'))
+                        if alert_start_time_utc >= time_threshold:
+                            print(f"\n--- Found NEW relevant VLLM Alert: {alertname} ---")
+                            slack_payload = format_slack_message(alert)
+                            send_slack_message(slack_payload)
+                            found = True
+                        else:
+                            print(f"VLLM alert '{alertname}' is active but started too long ago ({alert_start_time_utc}). Skipping.")
+                    except ValueError:
+                        print(f"Warning: Could not parse startsAt time for alert '{alertname}': {starts_at_iso}")
+        if not found:
+            print("No new alerts found")
+    else:
+        print("No alerts to process")
+
+def generate_test():
+    alert = json.loads('{"alertname": "VLLMHighAverageInferenceTime", "container": "kserve-container", "endpoint": "vllm-serving-runtime-metrics", "engine": "0", "expr": "rate(vllm:request_inference_time_seconds_sum[5m]) / rate(vllm:request_inference_time_seconds_count[5m]) > 2", "for": "5m", "instance": "10.129.2.73:8080", "job": "llama-3-2-3b-instruct-metrics", "model_name": "meta-llama/Llama-3.2-3B-Instruct", "namespace": "m3", "pod": "llama-3-2-3b-instruct-predictor-9fd74489-c6dwt", "prometheus": "openshift-user-workload-monitoring/user-workload", "service": "llama-3-2-3b-instruct-metrics", "severity": "warning"}')
+    desc = generate_description(alert)
+    print(desc)
+
+def main():
+    alerts = get_active_alerts()
+    process_vllm_alerts_and_notify(alerts)
+
+if __name__ == "__main__":
+    main()
+    # generate_test()


### PR DESCRIPTION
### Overview

Created alerting and Slack notification system for VLLM-relevant alerts. 
Jira: https://issues.redhat.com/browse/APPENG-3246

#### Changes:
- PrometheusRule CR with test alerts that monitor anomalies in vllm metrics
- Custom alert receiver that pulls alerts from Alertmanager and forwards them to a Slack channel given a webhook URL
- Helm charts to deploy PrometheusRule and cron job that runs the alert receiver every 1 minute
- Llamastack integration to generate custom slack messages for each alert based on its rule expression and other metadata

#### Testing Done
- Alert receiver script works locally when using a port-forwarded Alertmanager pod from the `openshift-user-workload-monitoring` namespace
- Helm chart installs correctly and cron job successfully sends alerts to Slack from the cluster

#### Deployment Steps:
1. [Enable cross-project alerting for namespace](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html-single/monitoring/index#managing-alerting-rules-for-user-defined-projects_managing-alerts-as-an-administrator)
2. Install the chart
```
helm install vllm-notifier ./deploy/helm/alerts --namespace <NAMESPACE>
```

### Screenshots

<img width="940" alt="Screenshot 2025-06-27 at 2 00 22 PM" src="https://github.com/user-attachments/assets/0ddb6c29-5adb-49ca-ba20-f89d7d7994c1" />
